### PR TITLE
2. Créer une page "Détail" pour afficher les informations complètes du psychologue

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -12,7 +12,7 @@ class HomepageController extends AbstractController
 {
     public function __invoke(SpecialistRepositoryInterface $specialistRepository): Response
     {
-        return $this->render('default/index.html.twig', [
+        return $this->render('homepage/index.html.twig', [
             'specialists' => $specialistRepository->search(onlineFirst: true),
         ]);
     }

--- a/src/Controller/Specialist/ShowController.php
+++ b/src/Controller/Specialist/ShowController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controller\Specialist;
+
+use App\Repository\SpecialistRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/psychologue/{id}', name: 'app_specialist_show')]
+class ShowController extends AbstractController
+{
+    public function __invoke(
+        SpecialistRepositoryInterface $specialistRepository,
+        int                           $id
+    ): Response
+    {
+        $specialist = $specialistRepository->findById($id);
+
+        if (!$specialist) {
+            throw $this->createNotFoundException('No specialist found for id ' . $id);
+        }
+
+        return $this->render('specialist/show.html.twig', [
+            'specialist' => $specialist,
+        ]);
+    }
+}

--- a/src/Entity/Specialist.php
+++ b/src/Entity/Specialist.php
@@ -42,6 +42,11 @@ class Specialist
         return $this->id;
     }
 
+    public function getName(): string
+    {
+        return sprintf("%s %s", $this->firstName, $this->lastName);
+    }
+    
     public function getFirstName(): ?string
     {
         return $this->firstName;

--- a/src/Factory/SpecialistFactory.php
+++ b/src/Factory/SpecialistFactory.php
@@ -39,7 +39,7 @@ final class SpecialistFactory extends ModelFactory
             'active' => self::faker()->boolean(),
             'description' => self::faker()->text(),
             'mobile' => '06' . self::faker()->numberBetween(10000000, 99999999),
-            'email' => '06' . self::faker()->email(),
+            'email' => self::faker()->email(),
             'city' => self::faker()->city(),
         ];
     }

--- a/src/Repository/Doctrine/SpecialistRepository.php
+++ b/src/Repository/Doctrine/SpecialistRepository.php
@@ -40,6 +40,22 @@ class SpecialistRepository extends ServiceEntityRepository implements Specialist
         }
     }
 
+    public function findById(int $id, bool $activeOnly = true): ?Specialist
+    {
+        $qb = $this
+            ->createQueryBuilder('specialist')
+            ->where('specialist.id = :id')
+            ->setParameter('id', $id);
+
+        if (true === $activeOnly) {
+            $qb->andWhere('specialist.active = true');
+        }
+
+        return $qb
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function search(bool $onlineFirst = true, bool $activeOnly = true): array
     {
         $qb = $this->createQueryBuilder('specialist');

--- a/src/Repository/SpecialistRepositoryInterface.php
+++ b/src/Repository/SpecialistRepositoryInterface.php
@@ -16,4 +16,10 @@ interface SpecialistRepositoryInterface
         bool $onlineFirst = false,
         bool $activeOnly = true
     ): array;
+
+    /**
+     * @param int $id id of the specialist
+     * @param bool $activeOnly filter on active specialists only
+     */
+    public function findById(int $id, bool $activeOnly = true): ?Specialist;
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -16,7 +16,7 @@
     <header>
         <div class="navbar navbar-dark bg-dark box-shadow">
             <div class="container d-flex justify-content-between">
-                <a href="#" class="navbar-brand d-flex align-items-center"><strong>Pros-Consulte</strong>
+                <a href="{{ path('app_homepage') }}" class="navbar-brand d-flex align-items-center"><strong>Pros-Consulte</strong>
                 </a>
             </div>
         </div>

--- a/templates/homepage/index.html.twig
+++ b/templates/homepage/index.html.twig
@@ -11,8 +11,14 @@
                         <div class="member-card pt-2 pb-2">
                             <div class="thumb-lg member-thumb mx-auto"><img src="{{ asset('build/avatar.png') }}" class="rounded-circle img-thumbnail" alt="profile-image"></div>
                             <div class="">
-                                <h4>{{ specialist.firstName }}</h4>
-                                <small>{{ specialist.online ? "En ligne" : "Hors ligne" }}</small>
+                                <h4>
+                                    <a href="{{ path('app_specialist_show', {'id': specialist.id}) }}">
+                                        {{ specialist.firstName }}
+                                    </a>
+                                </h4>
+                                <span class="mb-2 badge rounded-pill bg-{{ specialist.online ? "success" : "secondary" }} ">
+                                    {{ specialist.online ? "En ligne" : "Hors ligne" }}
+                                </span>
                             </div>
                             <a class="btn btn-primary" href="#">Appeler</a>
                         </div>

--- a/templates/specialist/show.html.twig
+++ b/templates/specialist/show.html.twig
@@ -1,0 +1,35 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Détail du profil de {{ specialist.name }}{% endblock %}
+
+{% block body %}
+    <div class="container mt-4">
+        <div id="member-show" class="row">
+            <div class="card mb-3 p-3">
+                <div class="row g-0">
+                    <div class="col-md-2">
+                        <img src="{{ asset('build/avatar.png') }}" 
+                             class="rounded-circle img-thumbnail"
+                             alt="profile-image"
+                        >
+                    </div>
+                    <div class="col-md-9">
+                        <div class="card-body">
+                            <h5 class="card-title mb-3">
+                                {{ specialist.name }}
+                                <small class="fw-light"> ({{ specialist.city }})</small>
+                                <span class="ms-2 badge rounded-pill bg-{{ specialist.online ? "success" : "secondary" }} ">
+                                    {{ specialist.online ? "En ligne" : "Hors ligne" }}
+                                </span>
+                            </h5>
+                            <p class="card-text">
+                                {{ specialist.description }}
+                            </p>
+                            <a class="btn btn-primary" href="#">Appeler</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Description   
Intégration de la page de détail d'un psychologue.    

J'ai présumé que la propriété `Specialist::active` était un status permettant de désactiver un psychologue pour qu'il ne soit pas accessible aux utilisateurs. 

## Dans cette PR
- Création du controller `Specialist\ShowController` + templating permettant d'afficher les informations d'un psychologue.
- Ajout de la méthode `SpecialistRepositoryInterface::findById()`. j'ai fait le choix de :
  1. Ne pas utiliser le [@ParamConverter](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/annotations/converters.html) de symfony pour éviter d'avoir la logique du `specialist->isActive()` dans le controller et de la concentrer dans le repository.
  2. Créer une méthode `SpecialistRepositoryInterface::findById`, et non pas `SpecialistRepositoryInterface::find()`, afin de garder de garder la main sur les type hint et de ne pas dépendre de l'abstraction de l'[`EntityRepository de doctrine`](https://github.com/webmozart/doctrine-orm/blob/master/lib/Doctrine/ORM/EntityRepository.php#L108) qui force des paramètres génériques. 